### PR TITLE
Replaced each with a 'for'

### DIFF
--- a/grails-app/conf/ActionLoggingFilters.groovy
+++ b/grails-app/conf/ActionLoggingFilters.groovy
@@ -81,8 +81,8 @@ class ActionLoggingFilters {
                     }
                     
                     def methods = controllerClass.getClazz().getMethods()
-                    methods.each { method ->
-                        if (method.getName() == actionNameValue) {
+                    for(method in methods) {
+                         if (method.getName() == actionNameValue) {
                             if (method.isAnnotationPresent(CustomActionName)) {
                                 def customActionNameAnnotation = method.getAnnotation(CustomActionName)
                                 def customActionNameObject = (CustomActionName) customActionNameAnnotation;
@@ -102,10 +102,10 @@ class ActionLoggingFilters {
                             if (method.isAnnotationPresent(PrintCustomLog)) {
                                 printCustomLogEnabled = method.getAnnotation(PrintCustomLog).value()
                             }
-                            return true
+                            break
                         }
                     }
-                    
+
                     def actionLoggingEvent = new ActionLoggingEvent(
                         controllerName: controllerNameValue,
                         actionName: actionNameValue,

--- a/grails-app/services/org/mirzsoft/grails/actionlogging/ActionLoggingService.groovy
+++ b/grails-app/services/org/mirzsoft/grails/actionlogging/ActionLoggingService.groovy
@@ -38,13 +38,13 @@ class ActionLoggingService {
         
         if (actionLoggingEvent) {
             if(printCustomLogEnabled){
-                println message
+                log.info message
             }
         
             actionLoggingEvent.customLog += "${message}\n"
             session.actionLoggingEvent = actionLoggingEvent    
         } else {
-            println "ActionLoggingEvent object not found."
+            log.info "ActionLoggingEvent object not found."
         }
     }
     
@@ -56,7 +56,7 @@ class ActionLoggingService {
             actionLoggingEvent.customActionName = customActionName
             session.actionLoggingEvent = actionLoggingEvent    
         } else {
-            println "ActionLoggingEvent object not found."
+            log.info "ActionLoggingEvent object not found."
         }
     }
     
@@ -68,7 +68,7 @@ class ActionLoggingService {
             actionLoggingEvent.actionType = actionType
             session.actionLoggingEvent = actionLoggingEvent    
         } else {
-            println "ActionLoggingEvent object not found."
+            log.info "ActionLoggingEvent object not found."
         }
     }
     
@@ -80,7 +80,7 @@ class ActionLoggingService {
             actionLoggingEvent.userId = userId
             session.actionLoggingEvent = actionLoggingEvent    
         } else {
-            println "ActionLoggingEvent object not found."
+            log.info "ActionLoggingEvent object not found."
         }
     }
     
@@ -101,9 +101,9 @@ class ActionLoggingService {
 
             def stacktrace = sw.getBuffer().toString()
 
-            actionLoggingEvent?.exceptionMessage = exFiltered.message
-            actionLoggingEvent?.exceptionStackTrace = stacktrace
-            actionLoggingEvent?.status = "ERROR"
+            actionLoggingEvent.exceptionMessage = exFiltered.message
+            actionLoggingEvent.exceptionStackTrace = stacktrace
+            actionLoggingEvent.status = "ERROR"
             
             session.actionLoggingEvent = actionLoggingEvent 
         }


### PR DESCRIPTION
Looping through all the methods is unnecessary. If we find a match, process the annotations and break the loop.

I think this could potentially impact the performance of your filter if the controller has a significant number of actions.
